### PR TITLE
refactor(Noder): optimize line splitting using ReadOnlySpan

### DIFF
--- a/src/CommonNovel/Noder.cs
+++ b/src/CommonNovel/Noder.cs
@@ -34,14 +34,14 @@ public partial class Compiler
 
             if (end is null) continue;
 
-            ReadOnlySpan<char> node = inputSpan[start..end.Value].TrimEnd(['\r', '\n']);
+            ReadOnlySpan<char> node = inputSpan[start..end.Value].Trim();
             nodeList.Add(node.ToString());
 
             start = end.Value;
         }
 
         if (start < inputSpan.Length)
-            nodeList.Add(inputSpan[start..].TrimEnd(['\r', '\n']).ToString());
+            nodeList.Add(inputSpan[start..].Trim().ToString());
 
         return nodeList.ToArray();
     }

--- a/src/CommonNovel/Noder.cs
+++ b/src/CommonNovel/Noder.cs
@@ -9,34 +9,34 @@ public partial class Compiler
     /// <returns>Nodes</returns>
     public static string[] Noder(string input)
     {
-        string[] lines = [];
-        string[] nodes = [];
+        ReadOnlySpan<char> inputSpan = input.AsSpan();
+        List<string> nodeList = [];
 
-        using (StringReader reader = new(input))
+        int start = 0;
+        for (int i = 0; i < inputSpan.Length; i++)
         {
-            string? line;
-            while ((line = reader.ReadLine()) != null)
-            {
-                lines = [.. lines, line];
-            }
+            int end;
+            if (inputSpan[i] != '\n') continue;
+
+            // "\n\n" (LF) or "\r\n\r\n" (CRLF) => Split
+            if (i + 1 < inputSpan.Length
+                        && inputSpan[i + 1] == '\n')
+                end = i + 2;
+            else if (i + 2 < inputSpan.Length
+                        && inputSpan[i + 1] == '\r'
+                        && inputSpan[i + 2] == '\n')
+                end = i + 3;
+            else continue;
+
+            ReadOnlySpan<char> node = inputSpan[start..end].TrimEnd(['\r', '\n']);
+            nodeList.Add(node.ToString());
+
+            start = end;
         }
 
-        int i = 0;
-        foreach (var line in lines)
-        {
-            if (string.IsNullOrWhiteSpace(line))
-            {
-                i++;
-                continue;
-            }
+        if (start < inputSpan.Length)
+            nodeList.Add(inputSpan[start..].TrimEnd(['\r', '\n']).ToString());
 
-            Array.Resize(ref nodes, i + 1);
-            if (string.IsNullOrWhiteSpace(nodes[i]))
-                nodes[i] = line;
-            else
-                nodes[i] += Environment.NewLine + line;
-        }
-
-        return nodes;
+        return nodeList.ToArray();
     }
 }

--- a/src/CommonNovel/Noder.cs
+++ b/src/CommonNovel/Noder.cs
@@ -15,23 +15,29 @@ public partial class Compiler
         int start = 0;
         for (int i = 0; i < inputSpan.Length; i++)
         {
-            int end;
+            int? end = null;
             if (inputSpan[i] != '\n') continue;
 
-            // "\n\n" (LF) or "\r\n\r\n" (CRLF) => Split
-            if (i + 1 < inputSpan.Length
-                        && inputSpan[i + 1] == '\n')
-                end = i + 2;
-            else if (i + 2 < inputSpan.Length
-                        && inputSpan[i + 1] == '\r'
-                        && inputSpan[i + 2] == '\n')
-                end = i + 3;
-            else continue;
+            // "\n\n" (LF) or "\r\n\r\n" (CRLF), "\n  \t\n" (tabs, spaces) => Split
+            for (int j = i + 1; j < inputSpan.Length; j++)
+            {
+                if (inputSpan[j] == '\n')
+                {
+                    end = j + 1;
+                    break;
+                }
+                if (char.IsWhiteSpace(inputSpan[j]) || (inputSpan[i] == '\r'))
+                    continue;
+                else
+                    break;
+            }
 
-            ReadOnlySpan<char> node = inputSpan[start..end].TrimEnd(['\r', '\n']);
+            if (end is null) continue;
+
+            ReadOnlySpan<char> node = inputSpan[start..end.Value].TrimEnd(['\r', '\n']);
             nodeList.Add(node.ToString());
 
-            start = end;
+            start = end.Value;
         }
 
         if (start < inputSpan.Length)

--- a/tests/CommonNovel.Tests/Noder.cs
+++ b/tests/CommonNovel.Tests/Noder.cs
@@ -48,6 +48,11 @@ public partial class CompilerUnitTest
             {
                 "- Alice",
                 (string[])[ "- Alice" ]
+            },
+            new object[] // spaces and tabs between newline-codes (\n or \r\n)
+            {
+                "\r\n  \t   \r\n",
+                (string[])[ "" ]
             }
         };
 }

--- a/tests/CommonNovel.Tests/Noder.cs
+++ b/tests/CommonNovel.Tests/Noder.cs
@@ -1,3 +1,5 @@
+using System.Diagnostics.CodeAnalysis;
+
 namespace CommonNovel.Tests;
 
 public partial class CompilerUnitTest
@@ -17,8 +19,7 @@ public partial class CompilerUnitTest
         }
     }
 
-    private static readonly string Nl = Environment.NewLine;
-
+    [ExcludeFromCodeCoverage]
     public static IEnumerable<object[]> NoderTestData =>
         new List<object[]>
         {
@@ -26,22 +27,27 @@ public partial class CompilerUnitTest
             {
                 "- Alice\r\n[Hi, Bob!]\r\n\r\n- Bob\r\n[Alice!]\r\n\r\n",
                 (string[])[
-                    $"- Alice{Nl}[Hi, Bob!]", // Future -> "\r\n"
-                    $"- Bob{Nl}[Alice!]" // Future -> "\r\n"
+                    "- Alice\r\n[Hi, Bob!]",
+                    "- Bob\r\n[Alice!]"
                 ]
             },
             new object[] // LF
             {
                 "- Alice\n[Hi, Bob!]\n\n- Bob\n[Alice!]\n\n",
                 (string[])[
-                    $"- Alice{Nl}[Hi, Bob!]", // Future -> '\n'
-                    $"- Bob{Nl}[Alice!]" // Future -> '\n'
+                    "- Alice\n[Hi, Bob!]",
+                    "- Bob\n[Alice!]"
                 ]
             },
             new object[] // three enters
             {
                 "\r\n\r\n\r\n",
-                (string[])[] // Future -> [ "", "" ]
+                (string[])[ "", "" ]
+            },
+            new object[] // single element
+            {
+                "- Alice",
+                (string[])[ "- Alice" ]
             }
         };
 }

--- a/tests/CommonNovel.Tests/Parser.cs
+++ b/tests/CommonNovel.Tests/Parser.cs
@@ -1,4 +1,6 @@
-﻿namespace CommonNovel.Tests;
+﻿using System.Diagnostics.CodeAnalysis;
+
+namespace CommonNovel.Tests;
 
 public partial class CompilerUnitTest
 {
@@ -20,6 +22,7 @@ public partial class CompilerUnitTest
         }
     }
 
+    [ExcludeFromCodeCoverage]
     public static IEnumerable<object[]> ParserTestData =>
         new List<object[]>
         {


### PR DESCRIPTION
## Summary

Improved the processes of Noder.

## Details

In Noder processing, replacing operations on `string` and `string[]` with `ReadOnlySpan` and `List<string>` has resulted in faster and more lightweight processing.

See also: https://github.com/AliceNovel/CommonNovel/pull/34/changes#diff-51e1cf45389002daed215ce0327155a875852fddba52326385b7afa56daabe09R10-R47

### Breaking Changes

> [!CAUTION]
> This PR contains breaking changes.

- (Change in interpretation) Changed the handling of line break codes from being environment-dependent to being character-dependent (Not specified in the specifications)
  - (This **need** to be specified in the specifications in the future) → #36
  - Before:
    - On Linux `\n` (LF) or `\r\n` (CRLF) → `\n` (LF)
    - On Windows `\n` (LF) or `\r\n` (CRLF) → `\r\n` (CRLF)
  - After:
    - Every where `\n` → `\n`, `\r\n` → `\r\n`
  - See also:
    - #36
  - Diff:
    -  https://github.com/AliceNovel/CommonNovel/pull/34/changes/ba9e898570bdac7fba6f4743b42bdfca46e28a4e#diff-8d94b27edaf5e79eac69939e49f85abd96cdb22d75754272178a1f32a391231eR26-R41
- Adjustments have been made so that nodes are created for all consecutive two-line sections where multiple line breaks occur.
  - (The previous implementation was incorrect and has been corrected to match the specifications.)
  - (In the previous implementation, even if lines were consecutive, no nodes were generated at all if the content was empty.)
  - Before:
    - `\n\n\n` → `[]` (no elements)
  - After:
    - `\n\n\n` → `[ "", "" ]` (two elements)
  - See also:
    - https://github.com/AliceNovel/CommonNovel/blob/627580ec2399e7fd652540c82118257b8d0167ce/docs/v0.1.x/v0.1.0.md?plain=1#L51
    - https://github.com/AliceNovel/CommonNovel/blob/627580ec2399e7fd652540c82118257b8d0167ce/docs/v0.1.x/v0.1.0.md?plain=1#L68-L79
  - Diff:
    -  https://github.com/AliceNovel/CommonNovel/pull/34/changes/ba9e898570bdac7fba6f4743b42bdfca46e28a4e#diff-8d94b27edaf5e79eac69939e49f85abd96cdb22d75754272178a1f32a391231eR42-R46

## Benchmark

```
BenchmarkDotNet v0.15.8, Windows 11 (10.0.26200.8328/25H2/2025Update/HudsonValley2)
13th Gen Intel Core i7-13700H 2.40GHz, 1 CPU, 20 logical and 14 physical cores
.NET SDK 10.0.103
  [Host]     : .NET 10.0.3 (10.0.3, 10.0.326.7603), X64 RyuJIT x86-64-v3
  DefaultJob : .NET 10.0.3 (10.0.3, 10.0.326.7603), X64 RyuJIT x86-64-v3
```

### Before

| Method      | Mean       | Error     | StdDev    | Gen0   | Allocated |
|------------ |-----------:|----------:|----------:|-------:|----------:|
| RunNoder    | 104.307 ns | 1.9910 ns | 3.8361 ns | 0.0497 |     624 B |

### After

| Method      | Mean       | Error     | StdDev     | Gen0   | Allocated |
|------------ |-----------:|----------:|-----------:|-------:|----------:|
| RunNoder    |  51.757 ns | 1.0359 ns |  1.1929 ns | 0.0197 |     248 B |
